### PR TITLE
reword his/her to their

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -96,18 +96,18 @@ Thomas Caswell. As Dictator, the BDFL has the authority to make all final
 decisions for The Project. As Benevolent, the BDFL, in practice chooses to
 defer that authority to the consensus of the community discussion channels and
 the Steering Council (see below). It is expected, and in the past has been the
-case, that the BDFL will only rarely assert his/her final authority. Because
+case, that the BDFL will only rarely assert their final authority. Because
 rarely used, we refer to BDFL’s final authority as a “special” or “overriding”
 vote. When it does occur, the BDFL override typically happens in situations
 where there is a deadlock in the Steering Council or if the Steering Council
 asks the BDFL to make a decision on a specific matter. To ensure the
 benevolence of the BDFL, The Project encourages others to fork the project if
 they disagree with the overall direction the BDFL is taking. The BDFL is chair
-of the Steering Council (see below) and may delegate his/her authority on a
-particular decision or set of decisions to any other Council member at his/her
+of the Steering Council (see below) and may delegate their authority on a
+particular decision or set of decisions to any other Council member at their
 discretion.
 
-The BDFL can appoint his/her successor, but it is expected that the Steering
+The BDFL can appoint their successor, but it is expected that the Steering
 Council would be consulted on this decision. If the BDFL is unable to appoint a
 successor, the Steering Council will make a suggestion or suggestions to the
 Main NumFOCUS Board. While the Steering Council and Main NumFOCUS Board will
@@ -201,7 +201,7 @@ All members of the Council, BDFL included, shall disclose to the rest of the
 Council any conflict of interest they may have. Members with a conflict of
 interest in a particular issue may participate in Council discussions on that
 issue, but must recuse themselves from voting on the issue. If the BDFL has
-recused his/herself for a particular decision, they will appoint a substitute
+recused themselves for a particular decision, they will appoint a substitute
 BDFL for that decision.
 
 ### Private communications of the Council


### PR DESCRIPTION
While reading this document I noted the "his/her" wording a lot, which sometimes seemed awkward.  As a trivial wording suggestion, this PR just changes that to "their" (which at least I think looks a bit cleaner)