### PR TITLE
overhaul governance 

### DIFF
--- a/communications_guidelines.md
+++ b/communications_guidelines.md
@@ -2,8 +2,8 @@
 These guidelines are applicable when acting as a representative of Matplotlib (for example at sprints or when giving official talks or tutorials) and in the following community venues managed by Matplotlib:
 * https://github.com/matplotlib/matplotlib
 * https://discourse.matplotlib.org/
-* https://gitter.im/matplotlib/ 
-* https://github.com/matplotlib/matplotblog 
+* https://gitter.im/matplotlib/
+* https://github.com/matplotlib/matplotblog
 * https://twitter.com/matplotlib
 * https://instagram.com/matplotart/
 
@@ -13,23 +13,23 @@ These guidelines are applicable when acting as a representative of Matplotlib (f
 - no gratuitous disparaging of other visualization libraries and tools; criticism is acceptable so long as it serves a constructive purpose
 - follow visualization communication best practices
     - don't share non-expert visualizations when it could be harmful
-      - put on meeting agenda when answer isn't clearly to hold off on sharing. 
+      - put on meeting agenda when answer isn't clearly to hold off on sharing.
     - clearly state when the visualization data/conclusions cannot be verified
       - do not rely on machine translations for sensitive visualizations
     - example: https://twitter.com/matplotlib/status/1244178154618605568
 - verify sourcing of content (especially on instagram & blog)
-    - Instagram/blog: ensure mpl has right to repost/share content 
+    - Instagram/blog: ensure mpl has right to repost/share content
     - make sure content is clearly cited
         - example: a tutorial using someone else’s example clearly cites the original source
-- Limited self/corporate promotion is acceptable, but should be no more than about a quarter of the content of the blog/discourse post. 
-- if you think content is borderline, ask before publishing it 
+- Limited self/corporate promotion is acceptable, but should be no more than about a quarter of the content of the blog/discourse post.
+- if you think content is borderline, ask before publishing it
 - acceptable image guide:
     - union of site guidelines favoring caution:
-        - keep  it geared towards science/data visualization, and non-controversial images 
+        - keep  it geared towards science/data visualization, and non-controversial images
     - site guidelines:
         - https://help.twitter.com/en/rules-and-policies/twitter-rules
         - https://help.instagram.com/477434105621119
-        
+
 ## Communication Guidelines
 - keep responses polite, assume user statements are in good faith unless they violate the [Code of Conduct](https://www.python.org/psf/conduct/)
 
@@ -37,14 +37,14 @@ These guidelines are applicable when acting as a representative of Matplotlib (f
 - Release Announcements
     - Highlight new features & major deprecations
     - Link to download/install instructions
-    - Ask folks to try it out. 
+    - Ask folks to try it out.
 - signal  boost third party packages
 - GSOC work during GSOC recruiting and work times
 - John Hunter Excellence in Plotting, submission and winners
 
 ## Social Media Following Guide:
-- only follow organizations/projects - mostly numfocus projects 
+- only follow organizations/projects - mostly numfocus projects
     - especially 3rd party packages
     - should at least be visualization related
     - sponsors are also acceptable
-- do not follow individual accounts for any reason (even maintainers/project leads/Guido!) 
+- do not follow individual accounts for any reason (even maintainers/project leads/Guido!)

--- a/contributor_roadmap.md
+++ b/contributor_roadmap.md
@@ -149,7 +149,7 @@ Curate a gallery of data and scientific visualization art made using Matplotlib
 -  at discretion of [communications lead](named_project_roles.md)
 
 ## Twitter
-twitter.com/matplotlib
+https://twitter.com/matplotlib
 
 Signal boost what’s new with the library & 3rd party packages, promote new work built on Matplotlib, and engage with the community. 
 

--- a/contributor_roadmap.md
+++ b/contributor_roadmap.md
@@ -6,43 +6,9 @@ on the exact permissions granted to each role is available at [github
 help](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level)
 
 
-# Github
-
-* https://github.com/matplotlib/matplotlib
-
-## Github Organization ownership
-Full control of everything on GH
-**People:**
-- Lead developer, steering council
 
 
-Want to keep this set small enough that we don’t have too much
-unneeded attack surface area, but big enough that we don’t have single
-point of failure.
-
-## Administration permissions
-
-Manages the administration of the Matplotlib github repositories.
-
-* https://github.com/orgs/matplotlib/teams/admin
-
-- Made up of steering council members, appointment process discussed here:
-    - https://github.com/matplotlib/governance/blob/master/governance.md#steering-council
-    - should decouple SC and admin power going forward
-**Responsibilities:**
-- add new repositories and teams to the matplotlib org
-- add members to Matplotlib teams
-- can delete / moderate issues
-
-- on a GH team that has “Admin” level permissions on all repositories
-## Release Powers
-- has publish permissions to pypi
-- Who has this
-    - Lead developer, steering council, release manager
-- responsibilities
-    - run release process
-
-## Development
+# Development
 Responsible for the codebase (including documentation)
 
 * https://github.com/orgs/matplotlib/teams/developers
@@ -63,10 +29,17 @@ Significant or sustained merged pull requests
 - including domain expertise as needed
 
 **Lose Commit privileges:**
-- no activity on the repository/calls in 6 months
+- no activity on the repository/calls/discourse/mailing lists in 6 months
 - repeated or severe violations of [merge guidelines](https://matplotlib.org/devdocs/devel/coding_guide.html)
 - potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
 
+# Release Powers
+- has publish permissions to pypi
+- has push access to macpython build system
+- Who has this
+    - Lead developer, steering council, release manager
+- responsibilities
+    - run release process
 
 # Community / communications
 
@@ -166,3 +139,34 @@ Signal boost what’s new with the library & 3rd party packages, promote new wor
 - repeated or severe violations of [+Social Media Guidelines](https://paper.dropbox.com/doc/Social-Media-Guidelines-GMgkvuznnxwtZpwFvPogS)
 - potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
 -  at discretion of [communications lead](named_project_roles.md)
+
+# Github
+
+* https://github.com/matplotlib/matplotlib
+
+## Github Organization ownership
+Full control of everything on GH
+**People:**
+- Lead developer, steering council
+
+
+Want to keep this set small enough that we don’t have too much
+unneeded attack surface area, but big enough that we don’t have single
+point of failure.
+
+## Administration permissions
+
+Manages the administration of the Matplotlib github repositories.
+
+* https://github.com/orgs/matplotlib/teams/admin
+
+- Made up of steering council members, appointment process discussed here:
+    - https://github.com/matplotlib/governance/blob/master/governance.md#steering-council
+    - should decouple SC and admin power going forward
+
+**Responsibilities:**
+- add new repositories and teams to the matplotlib org
+- add members to Matplotlib teams
+- can delete / moderate issues
+
+- on a GH team that has “Admin” level permissions on all repositories

--- a/contributor_roadmap.md
+++ b/contributor_roadmap.md
@@ -14,8 +14,7 @@ help](https://help.github.com/en/github/setting-up-and-managing-organizations-an
 Full control of everything on GH
 **People:**
 - Lead developer, steering council
-- someone from NF (?)
-- someone from outside?
+
 
 Want to keep this set small enough that we don’t have too much
 unneeded attack surface area, but big enough that we don’t have single

--- a/contributor_roadmap.md
+++ b/contributor_roadmap.md
@@ -149,7 +149,6 @@ Full control of everything on GH
 **People:**
 - Lead developer, steering council
 
-
 Want to keep this set small enough that we don’t have too much
 unneeded attack surface area, but big enough that we don’t have single
 point of failure.
@@ -165,8 +164,17 @@ Manages the administration of the Matplotlib github repositories.
     - should decouple SC and admin power going forward
 
 **Responsibilities:**
-- add new repositories and teams to the matplotlib org
-- add members to Matplotlib teams
-- can delete / moderate issues
-
 - on a GH team that has “Admin” level permissions on all repositories
+
+## Domain Team Member
+We have a number of sub-teams to maintain domain specific packages
+
+**Responsibilities:**
+- maintain those projects
+- have at least write premission on the repos for that project
+
+## Organization Member
+**Responsibilities:**
+- Can create and add members to Matplotlib teams
+- Can delete / moderate issues
+- Can create new repositories

--- a/contributor_roadmap.md
+++ b/contributor_roadmap.md
@@ -126,7 +126,7 @@ https://discourse.matplotlib.org/
 - sustained constructive participation in discussions
 
 **get suspended or banned:**
-- repeated or sever violations of [discourse guidelines](https://discourse.matplotlib.org/faq)
+- repeated or severe violations of [discourse guidelines](https://discourse.matplotlib.org/faq)
 - potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
 
 ## Instagram

--- a/contributor_roadmap.md
+++ b/contributor_roadmap.md
@@ -1,0 +1,165 @@
+# Contributor Roadmap/Expectations
+Hello, thank you for your interest in contributing to Matplotlib! 
+
+Matplotlib is primarily administered via github, so more information on the exact permissions granted to each role is available at [github help](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level)
+
+
+# Github
+
+* https://github.com/matplotlib/matplotlib
+
+## Github Organization ownership
+Full control of everything on GH
+**People:**
+- Lead developer, steering council
+- someone from NF (?)
+- someone from outside?
+
+Want to keep this set small enough that we don’t have too much unneeded attack surface area, but big enough that we don’t have single point of failure.
+
+## Administration permissions
+
+Manages the administration of the Matplotlib github repositories. 
+
+* https://github.com/orgs/matplotlib/teams/admin
+
+- Made up of steering council members, appointment process discussed here:
+    - https://github.com/matplotlib/governance/blob/master/governance.md#steering-council
+    - should decouple SC and admin power going forward
+**Responsibilities:**
+- add new repositories and teams to the matplotlib org
+- add members to Matplotlib teams
+- can delete / moderate issues
+    
+- on a GH team that has “Admin” level permissions on all repositories
+## Release Powers
+- has publish permissions to pypi
+- Who has this
+    - Lead developer, steering council, release manager
+- responsibilities
+    - run release process
+
+## Development
+Responsible for the codebase (including documentation)
+
+* https://github.com/orgs/matplotlib/teams/developers
+
+
+**contribute**: https://matplotlib.org/devdocs/devel/index.html
+
+**triage:**
+- triaging issues and pull requests means:
+    - assigning labels, milestones, and reviewers
+    - closing and reopening as needed
+    - marking duplicates
+- get triage privileges: granted on 1st merged pull request
+    - (We need to write the script for this, run as a service on heroku’s free tier?  can we do this with actions?)
+
+**Get commit privileges:**
+Significant or sustained merged pull requests 
+- including domain expertise as needed
+
+**Lose Commit privileges:**
+- no activity on the repository/calls in 6 months
+- repeated or severe violations of [merge guidelines](https://matplotlib.org/devdocs/devel/coding_guide.html)
+- potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
+
+
+# Community / communications
+
+Engages in community building, support, and outreach
+
+* https://github.com/orgs/matplotlib/teams/community
+
+## Blog
+writes and reviews blog posts about all things Matplotlib and made with Matplotlib
+* https://github.com/orgs/matplotlib/teams/blog
+* https://github.com/matplotlib/matplotblog
+
+**contribute**: 
+* https://matplotlib.org/matplotblog/posts/how-to-contribute/
+
+**get commit privileges:**  
+* sustained constructive reviews of contributed blog posts
+* at discretion of [communications lead](named_project_roles.md)
+
+**lose commit privileges:** 
+- repeated or severe violations of communications and social media guidelines
+- potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
+-  at discretion of [communications lead](named_project_roles.md)
+
+## Teaching
+Develops talks and tutorials to illustrated using and developing applications with Matplotlib
+
+* https://github.com/orgs/matplotlib/teams/teaching
+
+**contribute:**
+
+- significant or sustained contributions to:
+    - https://github.com/matplotlib/presentations
+    - https://discourse.matplotlib.org/c/showcase/tutorial
+- significant or sustained body of opens source teaching materials:
+    - book, long running blog series 
+
+**content guidelines:**
+
+-  [Social Media Guidelines](communications_guidelines.md) 
+- [Code of Conduct](https://www.python.org/psf/conduct/) 
+
+**removal from team:**
+- repeated or severe violations of [Social Media Guidelines](communications_guidelines.md)
+- potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
+-  at discretion of [communications or teaching lead](named_project_roles.md)
+
+## Discourse
+https://discourse.matplotlib.org/
+
+
+ Foster engagement on the discourse
+
+**contribute:**  
+* participate in discussion on https://discourse.matplotlib.org/
+
+**increasing trust level to access more privileges:**
+
+- https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/
+- sustained constructive participation in discussions
+
+**get suspended or banned:**
+- repeated or sever violations of [discourse guidelines](https://discourse.matplotlib.org/faq)
+- potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
+
+## Instagram
+instagram.com/matplotart/
+
+Curate a gallery of data and scientific visualization art made using Matplotlib
+
+**contribute:**  DM, tag #matplotlib, submit at http://bit.ly/matplotart
+
+**curate the account:** 
+
+- sustained positive contributions to Instagram 
+- sustained positive contributions to https://discourse.matplotlib.org/c/showcase
+- sustained positive tagging of matplotlib content on twitter
+
+**revoke curation privileges:**
+
+- repeated or severe violations of [Social Media Guidelines](communications_guidelines.md) 
+- potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
+-  at discretion of [communications lead](named_project_roles.md)
+
+## Twitter
+twitter.com/matplotlib
+
+Signal boost what’s new with the library & 3rd party packages, promote new work built on Matplotlib, and engage with the community. 
+
+**contribute:** tweet @matplotlib or tag #matplotlib
+
+**tweet as twitter account:**
+- be a lead on at least one of the other community projects
+
+**revoke twitter access:**
+
+- repeated or severe violations of [+Social Media Guidelines](https://paper.dropbox.com/doc/Social-Media-Guidelines-GMgkvuznnxwtZpwFvPogS) 
+- potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
+-  at discretion of [communications lead](named_project_roles.md)

--- a/contributor_roadmap.md
+++ b/contributor_roadmap.md
@@ -1,7 +1,9 @@
 # Contributor Roadmap/Expectations
-Hello, thank you for your interest in contributing to Matplotlib! 
+Hello, thank you for your interest in contributing to Matplotlib!
 
-Matplotlib is primarily administered via github, so more information on the exact permissions granted to each role is available at [github help](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level)
+Matplotlib is primarily administered via github, so more information
+on the exact permissions granted to each role is available at [github
+help](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level)
 
 
 # Github
@@ -15,11 +17,13 @@ Full control of everything on GH
 - someone from NF (?)
 - someone from outside?
 
-Want to keep this set small enough that we don’t have too much unneeded attack surface area, but big enough that we don’t have single point of failure.
+Want to keep this set small enough that we don’t have too much
+unneeded attack surface area, but big enough that we don’t have single
+point of failure.
 
 ## Administration permissions
 
-Manages the administration of the Matplotlib github repositories. 
+Manages the administration of the Matplotlib github repositories.
 
 * https://github.com/orgs/matplotlib/teams/admin
 
@@ -30,7 +34,7 @@ Manages the administration of the Matplotlib github repositories.
 - add new repositories and teams to the matplotlib org
 - add members to Matplotlib teams
 - can delete / moderate issues
-    
+
 - on a GH team that has “Admin” level permissions on all repositories
 ## Release Powers
 - has publish permissions to pypi
@@ -56,7 +60,7 @@ Responsible for the codebase (including documentation)
     - (We need to write the script for this, run as a service on heroku’s free tier?  can we do this with actions?)
 
 **Get commit privileges:**
-Significant or sustained merged pull requests 
+Significant or sustained merged pull requests
 - including domain expertise as needed
 
 **Lose Commit privileges:**
@@ -76,14 +80,14 @@ writes and reviews blog posts about all things Matplotlib and made with Matplotl
 * https://github.com/orgs/matplotlib/teams/blog
 * https://github.com/matplotlib/matplotblog
 
-**contribute**: 
+**contribute**:
 * https://matplotlib.org/matplotblog/posts/how-to-contribute/
 
-**get commit privileges:**  
+**get commit privileges:**
 * sustained constructive reviews of contributed blog posts
 * at discretion of [communications lead](named_project_roles.md)
 
-**lose commit privileges:** 
+**lose commit privileges:**
 - repeated or severe violations of communications and social media guidelines
 - potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
 -  at discretion of [communications lead](named_project_roles.md)
@@ -99,12 +103,12 @@ Develops talks and tutorials to illustrated using and developing applications wi
     - https://github.com/matplotlib/presentations
     - https://discourse.matplotlib.org/c/showcase/tutorial
 - significant or sustained body of opens source teaching materials:
-    - book, long running blog series 
+    - book, long running blog series
 
 **content guidelines:**
 
--  [Social Media Guidelines](communications_guidelines.md) 
-- [Code of Conduct](https://www.python.org/psf/conduct/) 
+-  [Social Media Guidelines](communications_guidelines.md)
+- [Code of Conduct](https://www.python.org/psf/conduct/)
 
 **removal from team:**
 - repeated or severe violations of [Social Media Guidelines](communications_guidelines.md)
@@ -117,7 +121,7 @@ https://discourse.matplotlib.org/
 
  Foster engagement on the discourse
 
-**contribute:**  
+**contribute:**
 * participate in discussion on https://discourse.matplotlib.org/
 
 **increasing trust level to access more privileges:**
@@ -136,22 +140,22 @@ Curate a gallery of data and scientific visualization art made using Matplotlib
 
 **contribute:**  DM, tag #matplotlib, submit at http://bit.ly/matplotart
 
-**curate the account:** 
+**curate the account:**
 
-- sustained positive contributions to Instagram 
+- sustained positive contributions to Instagram
 - sustained positive contributions to https://discourse.matplotlib.org/c/showcase
 - sustained positive tagging of matplotlib content on twitter
 
 **revoke curation privileges:**
 
-- repeated or severe violations of [Social Media Guidelines](communications_guidelines.md) 
+- repeated or severe violations of [Social Media Guidelines](communications_guidelines.md)
 - potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
 -  at discretion of [communications lead](named_project_roles.md)
 
 ## Twitter
 https://twitter.com/matplotlib
 
-Signal boost what’s new with the library & 3rd party packages, promote new work built on Matplotlib, and engage with the community. 
+Signal boost what’s new with the library & 3rd party packages, promote new work built on Matplotlib, and engage with the community.
 
 **contribute:** tweet @matplotlib or tag #matplotlib
 
@@ -160,6 +164,6 @@ Signal boost what’s new with the library & 3rd party packages, promote new wor
 
 **revoke twitter access:**
 
-- repeated or severe violations of [+Social Media Guidelines](https://paper.dropbox.com/doc/Social-Media-Guidelines-GMgkvuznnxwtZpwFvPogS) 
+- repeated or severe violations of [+Social Media Guidelines](https://paper.dropbox.com/doc/Social-Media-Guidelines-GMgkvuznnxwtZpwFvPogS)
 - potential repercussion of a [Code of Conduct](https://www.python.org/psf/conduct/) violation
 -  at discretion of [communications lead](named_project_roles.md)

--- a/governance.md
+++ b/governance.md
@@ -217,12 +217,12 @@ interests include, but are not limited to:
 -   Access to proprietary information of their employer that could potentially
     leak into their work with the Project.
 
-All members of the Council, BDFL included, shall disclose to the rest of the
+All members of the Council, LD included, shall disclose to the rest of the
 Council any conflict of interest they may have. Members with a conflict of
 interest in a particular issue may participate in Council discussions on that
-issue, but must recuse themselves from voting on the issue. If the BDFL has
+issue, but must recuse themselves from voting on the issue. If the LD has
 recused themselves for a particular decision, they will appoint a substitute
-BDFL for that decision.
+LD for that decision.
 
 ### Private communications of the Council
 

--- a/governance.md
+++ b/governance.md
@@ -83,7 +83,7 @@ Community.
 While this approach has served us well, as the Project grows and faces
 more legal and financial decisions and interacts with other
 institutions, we see a need for a more formal governance model. Moving
-forward, the Project leadership will consist of a Lead Developer,
+forward, the Project leadership will consist of a Project Leader,
 several Deputy Leads, and a Steering Council. We view this governance
 model as the formalization of what we are already doing, rather than a
 change in direction.
@@ -91,29 +91,29 @@ change in direction.
 Lead developer
 --------------
 
-The Project will have a Lead Developer (LD), who is currently Thomas A Caswell.
-The LD has the authority to make all final decisions for The Project.  In
-practice the LD chooses to defer that authority to the consensus of the
+The Project will have a Project Leader (PL), who is currently Thomas A Caswell.
+The PL has the authority to make all final decisions for The Project.  In
+practice the PL chooses to defer that authority to the consensus of the
 community discussion channels and the Steering Council (see below).  It is
-expected, and in the past has been the case, that the LD will only rarely assert
-their final authority.  Because rarely used, we refer to LD’s final authority as
-a “special” or “overriding” vote.  When it does occur, the LD override typically
+expected, and in the past has been the case, that the PL will only rarely assert
+their final authority.  Because rarely used, we refer to PL’s final authority as
+a “special” or “overriding” vote.  When it does occur, the PL override typically
 happens in situations where there is a deadlock in the Steering Council or if
-the Steering Council asks the LD to make a decision on a specific matter.
+the Steering Council asks the PL to make a decision on a specific matter.
 
-The LD is chair of the Steering Council (see below) and may delegate their
+The PL is chair of the Steering Council (see below) and may delegate their
 authority on a particular decision or set of decisions to any other Council
 member at their discretion.
 
-The LD can appoint their successor, but it is expected that the Steering Council
-would be consulted on this decision. If the LD is unable to appoint a successor,
+The PL can appoint their successor, but it is expected that the Steering Council
+would be consulted on this decision. If the PL is unable to appoint a successor,
 the Steering Council will make a suggestion or suggestions to the Main NumFOCUS
 Board. While the Steering Council and Main NumFOCUS Board will work together
-closely on the LD selection process, the Main NumFOCUS Board will make the final
+closely on the PL selection process, the Main NumFOCUS Board will make the final
 decision.
 
-To ensure the benevolence of the LD, The Project encourages others to fork the
-project if they disagree with the overall direction the LD is taking.
+To ensure the benevolence of the PL, The Project encourages others to fork the
+project if they disagree with the overall direction the PL is taking.
 
 Steering Council
 ----------------
@@ -121,7 +121,7 @@ Steering Council
 The Project will have a Steering Council that consists of Project Contributors
 who have produced contributions that are substantial in quality and quantity,
 and sustained over at least one year. The overall role of the Council is to
-ensure, through working with the LD and taking input from the Community, the
+ensure, through working with the PL and taking input from the Community, the
 long-term well-being of the project, technically, financially, and as a
 community.
 
@@ -147,7 +147,7 @@ situations. In particular, the Council may:
   an issue in a reasonable time frame.
 - Granting or revoking commit rights.
 
-The steering council will be between 5 and 7 people including the LD.  Being on
+The steering council will be between 5 and 7 people including the PL.  Being on
 the steering council is a responsibilty, not a recongnition of being a long-time
 contributor.
 
@@ -159,7 +159,7 @@ Project Contributor who has produced contributions that are substantial in
 quality and quantity, and sustained over at least one year.  Potential Council
 Members are nominated by existing Council members and voted upon by the existing
 Council after asking if the potential Member is interested and willing to serve
-in that capacity.  The Council will be initially formed through LD nomination
+in that capacity.  The Council will be initially formed through PL nomination
 from the set of existing Developers who meet the above criteria.
 
 When considering potential Members, the Council will look at candidates with a
@@ -178,12 +178,12 @@ for 2 years.  At the end of the two years they may elect to, with consent of the
 rest of the council, re-join the council.  If they chose to not re-join the
 council the process above is used to recruit new members.
 
-The Steering Council members, other than the LD, will serve in 2 equal classes
+The Steering Council members, other than the PL, will serve in 2 equal classes
 whose terms are offset by 1 year.  This will help preserve the continuity on the
 Steering Council over time.
 
 A Steering Council member can step down at anytime.  If a Council Member becomes
-inactive for a period of 2 months, they will be approached by the LD to see if
+inactive for a period of 2 months, they will be approached by the PL to see if
 they plan on returning to active participation.  If not they will be asked to
 step down, if the Council Member indicates they intend to be active again but
 have not done so after 1 month the Council my vote to remove them.
@@ -193,7 +193,7 @@ same process as above.  Their replacement will join the same class and serve the
 remainder of the 2 years.
 
 Each class can fluctuate between 2 and 3 members so long as the total council
-size (including the LD) is between 5 and 7.  If a class gets too small, an
+size (including the PL) is between 5 and 7.  If a class gets too small, an
 additional member must be recruited.
 
 All former Council members can be considered for membership again at any time in
@@ -201,13 +201,13 @@ the future, like any other Project Contributor. Retired Council members will be
 listed on the project website, acknowledging the period during which they were
 active in the Council.
 
-The Council reserves the right to eject current Members, other than the LD, if
+The Council reserves the right to eject current Members, other than the PL, if
 they are deemed to be actively harmful to the project’s well-being, and attempts
 at communication and conflict resolution have failed.
 
 ### Conflict of interest
 
-It is expected that the LD, DLDs, and Council Members will be employed at a wide
+It is expected that the PL, DPLs, and Council Members will be employed at a wide
 range of companies, universities and non-profit organizations. Because of this,
 it is possible that Members will have conflict of interests. Such conflict of
 interests include, but are not limited to:
@@ -217,12 +217,12 @@ interests include, but are not limited to:
 -   Access to proprietary information of their employer that could potentially
     leak into their work with the Project.
 
-All members of the Council, LD included, shall disclose to the rest of the
+All members of the Council, PL included, shall disclose to the rest of the
 Council any conflict of interest they may have. Members with a conflict of
 interest in a particular issue may participate in Council discussions on that
-issue, but must recuse themselves from voting on the issue. If the LD has
+issue, but must recuse themselves from voting on the issue. If the PL has
 recused themselves for a particular decision, they will appoint a substitute
-LD for that decision.
+PL for that decision.
 
 ### Private communications of the Council
 
@@ -264,24 +264,24 @@ interactions with NumFOCUS.
     person.
 
 
-Deputy Lead Developers
+Deputy Project Leaders
 ----------------------
 
-DLDs are nominated by Steering Council members and appointed to 1yr terms by a
+DPLs are nominated by Steering Council members and appointed to 1yr terms by a
 majority vote of the Steering council.  Any currently active Contributor is
-eligible to be considered for a DLD.  The Steering Council should take into account
+eligible to be considered for a DPL.  The Steering Council should take into account
 
-It is at the discretion of the SC and LD
-if any given DLD position is filled.
+It is at the discretion of the SC and PL
+if any given DPL position is filled.
 
-If a DLD position is not filled, the responsibility devolves back to the LD.    Each
-DLD appointment runs on its own calendar.
+If a DPL position is not filled, the responsibility devolves back to the PL.    Each
+DPL appointment runs on its own calendar.
 
-At the end of each year the DLD is given the option to continue for another year.
+At the end of each year the DPL is given the option to continue for another year.
 
-The SC can remove a DLD using the same process as ejecting a Steering Council Member.
+The SC can remove a DPL using the same process as ejecting a Steering Council Member.
 
-An individual may hold more than one DLD simultaneously.
+An individual may hold more than one DPL simultaneously.
 
 ### Release Manager
 
@@ -299,12 +299,12 @@ Project Specific Leads
 
 Matplotlib has a number of domain specific packages under it's umbrella and
 hosted on the matplotlib github organizations.  These projects will each have
-their own Lead Developer who can run the projects as they see fit.
+their own Project Leader who can run the projects as they see fit.
 
 Institutional Partners and Funding
 ==================================
 
-The LD and Steering Council are the primary leadership for the project. No
+The PL and Steering Council are the primary leadership for the project. No
 outside institution, individual or legal entity has the ability to own,
 control, usurp or influence the project other than by participating in the
 Project as Contributors and Council Members. However, because institutions are
@@ -344,7 +344,7 @@ raising money from private foundations and donors or a for-profit company
 building proprietary products and services that leverage Project Software and
 Services. Funding acquired by Institutional Partners to work on The Project is
 called Institutional Funding. However, no funding obtained by an Institutional
-Partner can override The Project LD and Steering Council. If a Partner has
+Partner can override The Project PL and Steering Council. If a Partner has
 funding to do Matplotlib work and the Council decides to not pursue that
 work as a project, the Partner is free to pursue it on their own. However in
 this situation, that part of the Partner’s work will not be under the
@@ -374,6 +374,6 @@ Member should state the final commit hash in the pull request being proposed for
 acceptance or rejection and briefly summarize the pull request. The full
 Steering Council must vote and at least 2/3 of the votes must be positive to
 carry out the proposed action (fractions of a vote rounded up to the nearest
-integer). Since the LD holds ultimate authority in The Project, the LD has
+integer). Since the PL holds ultimate authority in The Project, the PL has
 authority to act alone in accepting or rejecting changes or overriding Steering
 Council decisions.

--- a/governance.md
+++ b/governance.md
@@ -267,7 +267,7 @@ interactions with NumFOCUS.
 Institutional Partners and Funding
 ==================================
 
-The BDFL and Steering Council are the primary leadership for the project. No
+The LD and Steering Council are the primary leadership for the project. No
 outside institution, individual or legal entity has the ability to own,
 control, usurp or influence the project other than by participating in the
 Project as Contributors and Council Members. However, because institutions are
@@ -309,7 +309,7 @@ raising money from private foundations and donors or a for-profit company
 building proprietary products and services that leverage Project Software and
 Services. Funding acquired by Institutional Partners to work on The Project is
 called Institutional Funding. However, no funding obtained by an Institutional
-Partner can override The Project BDFL and Steering Council. If a Partner has
+Partner can override The Project LD and Steering Council. If a Partner has
 funding to do Matplotlib work and the Council decides to not pursue that
 work as a project, the Partner is free to pursue it on their own. However in
 this situation, that part of the Partner’s work will not be under the
@@ -341,7 +341,7 @@ should state the final commit hash in the pull request being proposed
 for acceptance or rejection and briefly summarize the pull request. A
 minimum of 80% of the Steering Council must vote and at least 2/3 of
 the votes must be positive to carry out the proposed action (fractions
-of a vote rounded up to the nearest integer). Since the BDFL holds
-ultimate authority in The Project, the BDFL has authority to act alone
+of a vote rounded up to the nearest integer). Since the LD holds
+ultimate authority in The Project, the LD has authority to act alone
 in accepting or rejecting changes or overriding Steering Council
 decisions.

--- a/governance.md
+++ b/governance.md
@@ -156,42 +156,58 @@ contributor.
 
 To become eligible for being a Steering Council Member an individual must be a
 Project Contributor who has produced contributions that are substantial in
-quality and quantity, and sustained over at least one year. Potential Council
-Members are nominated by existing Council members and voted upon by the
-existing Council after asking if the potential Member is interested and willing
-to serve in that capacity. The Council will be initially formed through BDFL
-nomination from the set of existing Developers who meet the above criteria.
+quality and quantity, and sustained over at least one year.  Potential Council
+Members are nominated by existing Council members and voted upon by the existing
+Council after asking if the potential Member is interested and willing to serve
+in that capacity.  The Council will be initially formed through LD nomination
+from the set of existing Developers who meet the above criteria.
 
 When considering potential Members, the Council will look at candidates with a
-comprehensive view of their contributions. This will include but is not limited
+comprehensive view of their contributions.  This will include but is not limited
 to code, code review, infrastructure work, mailing list and chat participation,
-community help/building, education and outreach, design work, etc. We are
+community help/building, education and outreach, design work, etc.  We are
 deliberately not setting arbitrary quantitative metrics (like “100 commits in
 this repo”) to avoid encouraging behavior that plays to the metrics rather than
-the project’s overall well-being. We want to encourage a diverse array of
+the project’s overall well-being.  We want to encourage a diverse array of
 backgrounds, viewpoints and talents in our team, which is why we explicitly do
 not define code as the sole metric on which council membership will be
 evaluated.
 
-If a Council member becomes inactive in the project for a period of one year,
-they will be considered for removal from the Council. Before removal, inactive
-Member will be approached by the BDFL to see if they plan on returning to
-active participation. If not they will be removed immediately upon a Council
-vote. If they plan on returning to active participation soon, they will be
-given a grace period of one year. If they don’t return to active participation
-within that time period they will be removed by vote of the Council without
-further grace period. All former Council members can be considered for
-membership again at any time in the future, like any other Project Contributor.
-Retired Council members will be listed on the project website, acknowledging
-the period during which they were active in the Council.
+When invited to join the Steering Council Contributors are commiting to serve
+for 2 years.  At the end of the two years they may elect to, with consent of the
+rest of the council, re-join the council.  If they chose to not re-join the
+council the process above is used to recruit new members.
 
-The Council reserves the right to eject current Members, other than the BDFL,
-if they are deemed to be actively harmful to the project’s well-being, and
-attempts at communication and conflict resolution have failed.
+The Steering Council members, other than the LD, will serve in 2 equal classes
+whose terms are offset by 1 year.  This will help preserve the continuity on the
+Steering Council over time.
+
+A Steering Council member can step down at anytime.  If a Council Member becomes
+inactive for a period of 2 months, they will be approached by the LD to see if
+they plan on returning to active participation.  If not they will be asked to
+step down, if the Council Member indicates they intend to be active again but
+have not done so after 1 month the Council my vote to remove them.
+
+If a Council Member leaves the council early they may be replaced, using the
+same process as above.  Their replacement will join the same class and serve the
+remainder of the 2 years.
+
+Each class can fluctuate between 2 and 3 members so long as the total council
+size (including the LD) is between 5 and 7.  If a class gets too small, an
+additional member must be recruited.
+
+All former Council members can be considered for membership again at any time in
+the future, like any other Project Contributor. Retired Council members will be
+listed on the project website, acknowledging the period during which they were
+active in the Council.
+
+The Council reserves the right to eject current Members, other than the LD, if
+they are deemed to be actively harmful to the project’s well-being, and attempts
+at communication and conflict resolution have failed.
 
 ### Conflict of interest
 
-It is expected that the BDFL and Council Members will be employed at a wide
+It is expected that the LD, DLDs, and Council Members will be employed at a wide
 range of companies, universities and non-profit organizations. Because of this,
 it is possible that Members will have conflict of interests. Such conflict of
 interests include, but are not limited to:

--- a/governance.md
+++ b/governance.md
@@ -74,7 +74,7 @@ Project leadership was initially provided by the original author, John
 D. Hunter.  Shortly before his passing in 2012, leadership was
 transferred to Michael Droettboom, who later invited Thomas Caswell as
 a co-lead.  Additional leadership has also been provided by a subset
-of Contributors, called Developers, whose active and consistent
+of Contributors, called Developers, whose significant or consistent
 contributions have been recognized by their receiving “commit rights”
 to the Project repositories. In general all Project decisions are made
 through consensus among the Developers with input from the

--- a/governance.md
+++ b/governance.md
@@ -30,7 +30,7 @@ Development Team (MDT)" in the project license.  Anyone can be a
 Contributor. Contributors can be affiliated with any legal entity or
 none. Contributors participate in the project by submitting, reviewing
 and discussing GitHub Pull Requests and Issues and participating in
-open and public Project discussions on GitHub, Google+, Hackpad,
+open and public Project discussions on GitHub, discourse, Hackpad,
 Gitter chat rooms and mailing lists. The foundation of Project
 participation is openness and transparency.
 

--- a/governance.md
+++ b/governance.md
@@ -267,39 +267,154 @@ interactions with NumFOCUS.
 Deputy Project Leaders
 ----------------------
 
-DPLs are nominated by Steering Council members and appointed to 1yr terms by a
-majority vote of the Steering council.  Any currently active Contributor is
-eligible to be considered for a DPL.  The Steering Council should take into account
+DPLs (except for Release Manager) are nominated by Steering Council
+members and appointed to a 1yr term from their appointment date by a
+majority vote of the Steering council.  Any currently active
+Contributor is eligible to be considered for a DPL.
 
-It is at the discretion of the SC and PL
-if any given DPL position is filled.
-
-If a DPL position is not filled, the responsibility devolves back to the PL.    Each
-DPL appointment runs on its own calendar.
-
-At the end of each year the DPL is given the option to continue for another year.
-
-The SC can remove a DPL using the same process as ejecting a Steering Council Member.
+As with the PL, the DPL should strive to reach consensus about any
+issues with in their scope before invoking their authority to decide.
+Their decisions can be appealed to the PL, but the PL should defer to
+the DPL except in extraordinary circumstances.
 
 An individual may hold more than one DPL simultaneously.
 
-### Release Manager
+It is at the discretion of the SC and PL if any given DPL position is
+filled.
+
+If a DPL position is not filled, the responsibility devolves back to
+the PL.
+
+At each 1yr term a DPL has the option to continue for another year or
+step down.
+
+The SC can remove a DPL using the same process as ejecting a Steering
+Council Member.
+
+The SC can create a new DPL position or eliminate an unfilled DPL
+position by majority vote.
 
 
-### Narrative Documentation Lead
+### Release Manager(s)
 
-### API Documentation Lead
+The Release Manager (RM) is appointed for a minor version (A.B.x)
+release series of Matplotlib.  They are responsible for the full
+release life cycle of all minor releases in the series including:
 
-### Communication and Community Lead
+- ensuring the whats new, API changes, and release notes are up to date
+- the timing of the releases
+- what changes should or should not be backported from the master
+  branch
+- rebuilding and publishing the website
+- announcing the release
+- publishing sdist and wheels to pypi
+- notifying down-stream packagers of the release
 
-### API consistency Lead
+An individual can be the RM as more than one release series at the
+same time.
+
+
+### Narrative Documentation Manager
+
+Matplotlib has a tremendous amount of documentation that is narrative
+in form.  This includes our examples and tutorials that live inside the
+main source repository and longer tutorials that live in other repositories
+in the Matplotlib organization.
+
+The Narrative Documentation Matplotlib (NDM) is responsible for
+shepherding all of this content including the scope, level, tone, and
+voice.
+
+### Reference Documentation Manager
+
+Matplotlib also has a tremendous amount of reference documentation
+embedded in doc strings.  This documentation needs to be complete and
+accurate as our users rely on it as the last authority of what a given
+method will do (short of reading the source).
+
+The Reference Documentation Manager (RDM) is responsible for ensuring that
+the docstrings are:
+
+- correctly formatted and render as intended
+- technically correct
+- complete
+
+### Community Manager
+
+The true strength of Matplotlib and why it has had such longevity as a
+project is the community of people around the code.  That community
+needs to be maintained.  The Community Manager (CM) is the is a
+catch-all for several very diverse tasks and this role may be split
+in the future and may want to enlist further assistants.
+
+**Communications**
+
+We need to maintain communication channels with the wider world.  To this end
+the CM is responsible for maintaining:
+
+- Matplotlib's social media presence
+- The Matplotlib blog
+- Recruiting people to give talks on Matplotlib at conferences / meetups
+- Maintaining a "matplotlib update" slide deck
+- the [Ann] mailing list
+
+This communication is primarily broadcast out and intended to engage
+with end-users.
+
+**Developer Relations**
+
+In addition to communication to end-users we need to maintain
+communication channels to developers of down-stream libraries and
+other expert users.
+
+- GSOC/mentoring programs
+- Recruiting people to run sprints
+- interaction with 3rd party extensions / publicity
+- [user]/[dev] mailing list moderation
+- Managing the discourse
+- recruiting new contributors
+
+**Event and Meeting planning**
+
+From time to time Matplotlib as an organization has in-person
+meetings.
+
+
+### API consistency Leader
+
+Matplotlib is constantly making small changes to our API: enhancements
+that add new features, bug fixes that unavoidably change behavior, and
+deprecation of inconsistent or undesired functionality.  The API
+Consistency Leader (ACL) is responsible for making sure that these
+incremental changes to the library are done in a coherent and
+consistent manner.
+
+This include checking that:
+
+- new functionality is not duplicating existing functionality
+- deprecations are justified and properly documented
+- new functionality does not "paint us into a corner" for future work
+- new functionality is implemented with an API that is consistent with
+  the existing functions
+
+
+### Secretary
+- Responsible for maintaining the weekly notes
+- Responsible for ensuring that any decisions taken by vote in the SC
+  are properly recorded.
 
 Project Specific Leads
 ----------------------
 
 Matplotlib has a number of domain specific packages under it's umbrella and
 hosted on the matplotlib github organizations.  These projects will each have
-their own Project Leader who can run the projects as they see fit.
+their own Project Leader who can run the projects as they see fit consistent with
+the Matplotlib Code of Conduct.
+
+If a project would like to be hosted on the Matplotlib organization on
+GitHub, they can petition the SC and be accepted by a simple majority
+vote.  A project can leave the organization at any time and can be
+removed from the organization by an 2/3 majority vote of the SC.
 
 Institutional Partners and Funding
 ==================================

--- a/governance.md
+++ b/governance.md
@@ -294,6 +294,13 @@ An individual may hold more than one DLD simultaneously.
 
 ### API consistency Lead
 
+Project Specific Leads
+----------------------
+
+Matplotlib has a number of domain specific packages under it's umbrella and
+hosted on the matplotlib github organizations.  These projects will each have
+their own Lead Developer who can run the projects as they see fit.
+
 Institutional Partners and Funding
 ==================================
 

--- a/governance.md
+++ b/governance.md
@@ -325,20 +325,18 @@ following benefits:
 Changing the Governance Documents
 =================================
 
-Changes to the governance documents are submitted via a GitHub pull
-request to The Project's governance documents GitHub repository at
+Changes to the governance documents are submitted via a GitHub pull request to
+The Project's governance documents GitHub repository at
 [https://github.com/matplotlib/governance](https://github.com/matplotlib/governance).
-The pull request is then refined in response to public comment and
-review, with the goal being consensus in the community.  After this
-open period, a Steering Council Member proposes to the Steering
-Council that the changes be ratified and the pull request merged
-(accepting the proposed changes) or proposes that the pull request be
-closed without merging (rejecting the proposed changes).  The Member
-should state the final commit hash in the pull request being proposed
-for acceptance or rejection and briefly summarize the pull request. A
-minimum of 80% of the Steering Council must vote and at least 2/3 of
-the votes must be positive to carry out the proposed action (fractions
-of a vote rounded up to the nearest integer). Since the LD holds
-ultimate authority in The Project, the LD has authority to act alone
-in accepting or rejecting changes or overriding Steering Council
-decisions.
+The pull request is then refined in response to public comment and review, with
+the goal being consensus in the community.  After this open period, a Steering
+Council Member proposes to the Steering Council that the changes be ratified and
+the pull request merged (accepting the proposed changes) or proposes that the
+pull request be closed without merging (rejecting the proposed changes).  The
+Member should state the final commit hash in the pull request being proposed for
+acceptance or rejection and briefly summarize the pull request. The full
+Steering Council must vote and at least 2/3 of the votes must be positive to
+carry out the proposed action (fractions of a vote rounded up to the nearest
+integer). Since the LD holds ultimate authority in The Project, the LD has
+authority to act alone in accepting or rejecting changes or overriding Steering
+Council decisions.

--- a/governance.md
+++ b/governance.md
@@ -121,32 +121,35 @@ Steering Council
 The Project will have a Steering Council that consists of Project Contributors
 who have produced contributions that are substantial in quality and quantity,
 and sustained over at least one year. The overall role of the Council is to
-ensure, through working with the BDFL and taking input from the Community, the
-long-term well-being of the project, both technically and as a community.
+ensure, through working with the LD and taking input from the Community, the
+long-term well-being of the project, technically, financially, and as a
+community.
 
 During the everyday project activities, council members participate in all
 discussions, code review and other project activities as peers with all other
-Contributors and the Community. In these everyday activities, Council Members
-do not have any special power or privilege through their membership on the
+Contributors and the Community. In these everyday activities, Council Members do
+not have any special power or privilege through their membership on the
 Council. However, it is expected that because of the quality and quantity of
 their contributions and their expert knowledge of the Project Software and
 Services that Council Members will provide useful guidance, both technical and
 in terms of project direction, to potentially less experienced contributors.
 
-The Steering Council and its Members play a special role in certain situations.
-In particular, the Council may:
+The Steering Council and its Members play a special role in certain
+situations. In particular, the Council may:
 
--   Make decisions about the overall scope, vision and direction of the
-    project.
--   Make decisions about strategic collaborations with other organizations or
-    individuals.
--   Make decisions about the Services that are run by The Project and manage
-    those Services for the benefit of the Project and Community.
--   Granting or revoking commit rights.
--   Make decisions when regular community discussion doesn’t produce consensus
-    on an issue in a reasonable time frame.
--   Develop funding sources and spending money (see Finance sub
-    committee below).
+- Develop funding sources and spending money (see Finance sub committee below).
+- Make decisions about the overall scope, vision and direction of the project.
+- Make decisions about strategic collaborations with other organizations or
+  individuals.
+- Make decisions about the Services that are run by The Project and manage those
+  Services for the benefit of the Project and Community.
+- Make decisions when regular community discussion doesn’t produce consensus on
+  an issue in a reasonable time frame.
+- Granting or revoking commit rights.
+
+The steering council will be between 5 and 7 people including the LD.  Being on
+the steering council is a responsibilty, not a recongnition of being a long-time
+contributor.
 
 
 ### Council membership

--- a/governance.md
+++ b/governance.md
@@ -88,31 +88,32 @@ several Deputy Leads, and a Steering Council. We view this governance
 model as the formalization of what we are already doing, rather than a
 change in direction.
 
-BDFL
-----
+Lead developer
+--------------
 
-The Project will have a BDFL (Benevolent Dictator for Life), who is currently
-Thomas Caswell. As Dictator, the BDFL has the authority to make all final
-decisions for The Project. As Benevolent, the BDFL, in practice chooses to
-defer that authority to the consensus of the community discussion channels and
-the Steering Council (see below). It is expected, and in the past has been the
-case, that the BDFL will only rarely assert their final authority. Because
-rarely used, we refer to BDFL’s final authority as a “special” or “overriding”
-vote. When it does occur, the BDFL override typically happens in situations
-where there is a deadlock in the Steering Council or if the Steering Council
-asks the BDFL to make a decision on a specific matter. To ensure the
-benevolence of the BDFL, The Project encourages others to fork the project if
-they disagree with the overall direction the BDFL is taking. The BDFL is chair
-of the Steering Council (see below) and may delegate their authority on a
-particular decision or set of decisions to any other Council member at their
-discretion.
+The Project will have a Lead Developer (LD), who is currently Thomas A Caswell.
+The LD has the authority to make all final decisions for The Project.  In
+practice the LD chooses to defer that authority to the consensus of the
+community discussion channels and the Steering Council (see below).  It is
+expected, and in the past has been the case, that the LD will only rarely assert
+their final authority.  Because rarely used, we refer to LD’s final authority as
+a “special” or “overriding” vote.  When it does occur, the LD override typically
+happens in situations where there is a deadlock in the Steering Council or if
+the Steering Council asks the LD to make a decision on a specific matter.
 
-The BDFL can appoint their successor, but it is expected that the Steering
-Council would be consulted on this decision. If the BDFL is unable to appoint a
-successor, the Steering Council will make a suggestion or suggestions to the
-Main NumFOCUS Board. While the Steering Council and Main NumFOCUS Board will
-work together closely on the BDFL selection process, the Main NumFOCUS Board
-will make the final decision.
+The LD is chair of the Steering Council (see below) and may delegate their
+authority on a particular decision or set of decisions to any other Council
+member at their discretion.
+
+The LD can appoint their successor, but it is expected that the Steering Council
+would be consulted on this decision. If the LD is unable to appoint a successor,
+the Steering Council will make a suggestion or suggestions to the Main NumFOCUS
+Board. While the Steering Council and Main NumFOCUS Board will work together
+closely on the LD selection process, the Main NumFOCUS Board will make the final
+decision.
+
+To ensure the benevolence of the LD, The Project encourages others to fork the
+project if they disagree with the overall direction the LD is taking.
 
 Steering Council
 ----------------

--- a/governance.md
+++ b/governance.md
@@ -399,6 +399,8 @@ This include checking that:
 
 
 ### Secretary
+- Responsible for ensure that there is an agenda for the weekly
+  meeting at it is followed.
 - Responsible for maintaining the weekly notes
 - Responsible for ensuring that any decisions taken by vote in the SC
   are properly recorded.

--- a/governance.md
+++ b/governance.md
@@ -286,18 +286,16 @@ in the United States or elsewhere that employs at least one Institutional
 Contributor or Institutional Council Member. Institutional Partners can be
 for-profit or non-profit entities.
 
-Institutions become eligible to become an Institutional Partner by
-employing individuals who actively contribute to The Project as part
-of their official duties. To state this another way, the only way for
-an Institutional Partner to influence the project is by actively
-contributing to the open development of the project, on equal terms
-with any other member of the community of Contributors and Council
-Members. Merely using Matplotlib Software or Services in an
-institutional context does not allow an entity to become an
-Institutional Partner. Financial gifts do not enable an entity to
-become an Institutional Partner. Once an institution becomes eligible
-for Institutional Partnership, the Steering Council must nominate and
-approve the Partnership.
+Institutions become eligible to become an Institutional Partner by employing
+individuals who actively contribute to The Project as part of their official
+duties. To state this another way, the only way for an Institutional Partner to
+influence the project is by actively contributing to the open development of the
+project, on equal terms with any other member of the community of Contributors
+and Council Members. Merely using Matplotlib Software in an institutional
+context does not allow an entity to become an Institutional Partner. Financial
+gifts do not enable an entity to become an Institutional Partner. Once an
+institution becomes eligible for Institutional Partnership, the Steering Council
+must nominate and approve the Partnership.
 
 If an existing Institutional Partner no longer has a contributing employee,
 they will be given a one-year grace period for other employees to begin
@@ -316,14 +314,13 @@ this situation, that part of the Partner’s work will not be under the
 Matplotlib umbrella and cannot use the Project trademarks in a way that
 suggests a formal relationship.
 
-To acknowledge institutional contributions, Institutional Partners
-receive the following benefits:
+To acknowledge institutional contributions, Institutional Partners receive the
+following benefits:
 
 -   Acknowledged on the Matplotlib websites, in talks and T-shirts.
--   Ability to acknowledge their own funding sources on the Matplotlib
-    websites, in talks and T-shirts.
--   Ability to influence the project through the participation of their Council
-    Member.
+-   Ability to acknowledge their own funding sources on the Matplotlib websites,
+    in talks and T-shirts.
+
 
 Changing the Governance Documents
 =================================

--- a/governance.md
+++ b/governance.md
@@ -264,6 +264,36 @@ interactions with NumFOCUS.
     person.
 
 
+Deputy Lead Developers
+----------------------
+
+DLDs are nominated by Steering Council members and appointed to 1yr terms by a
+majority vote of the Steering council.  Any currently active Contributor is
+eligible to be considered for a DLD.  The Steering Council should take into account
+
+It is at the discretion of the SC and LD
+if any given DLD position is filled.
+
+If a DLD position is not filled, the responsibility devolves back to the LD.    Each
+DLD appointment runs on its own calendar.
+
+At the end of each year the DLD is given the option to continue for another year.
+
+The SC can remove a DLD using the same process as ejecting a Steering Council Member.
+
+An individual may hold more than one DLD simultaneously.
+
+### Release Manager
+
+
+### Narrative Documentation Lead
+
+### API Documentation Lead
+
+### Communication and Community Lead
+
+### API consistency Lead
+
 Institutional Partners and Funding
 ==================================
 

--- a/governance.md
+++ b/governance.md
@@ -83,9 +83,9 @@ Community.
 While this approach has served us well, as the Project grows and faces
 more legal and financial decisions and interacts with other
 institutions, we see a need for a more formal governance model. Moving
-forward, the Project leadership will consist of a Benevolent Dictator
-for Life (BDFL) and a Steering Council. We view this governance model
-as the formalization of what we are already doing, rather than a
+forward, the Project leadership will consist of a Lead Developer,
+several Deputy Leads, and a Steering Council. We view this governance
+model as the formalization of what we are already doing, rather than a
 change in direction.
 
 BDFL

--- a/governance.md
+++ b/governance.md
@@ -228,11 +228,12 @@ LD for that decision.
 
 Unless specifically required, all Council discussions and activities will be
 public and done in collaboration and discussion with the Project Contributors
-and Community. The Council will have a private mailing list that will be used
-sparingly and only when a specific matter requires privacy. When private
-communications and decisions are needed, the Council will do its best to
-summarize those to the Community after eliding personal/private/sensitive
-information that should not be posted to the public internet.
+and Community through the normal communication channels. The Council will have a
+private mailing list that will be used sparingly and only when a specific matter
+requires privacy. When private communications and decisions are needed, the
+Council will do its best to summarize those to the Community after eliding
+personal/private/sensitive information that should not be posted to the public
+internet.
 
 ### Subcommittees
 

--- a/named_project_roles.md
+++ b/named_project_roles.md
@@ -1,0 +1,19 @@
+# Named roles:
+## Release Manager
+- Responsibility: manage the release
+## API change shepherd 
+- Responsibility: make sure all API changes are documented and justified
+## Technical/Reference Documentation lead
+- makes sure API docs are correct, up-to-date and complete
+## User Documentation lead
+- Example / Tutorial / Teaching lead
+- some of this is docs, some of it is comms
+## Comms / community lead
+- Oversees all communication related things
+- does community stuff count here?
+## Lead Developer
+- Responsibility: project leadership
+## NF liaison
+## \<domain package lead\>
+- has admin rights on their package
+- can run their team like they want


### PR DESCRIPTION
Based on this weeks dev call, temporarily putting the following docs here:
* Social Media/Communications Guidelines 
* Contributor Roadmap
* Named Roles (which maybe should be part of the [people](https://github.com/matplotlib/governance/blob/master/people.md)?
Sorry, didn't realize I could push directly to this repo. 🙁 