### PR TITLE
GOV: add Tim Hoffmann to the steering council

### DIFF
--- a/people.md
+++ b/people.md
@@ -9,7 +9,7 @@ Thomas Caswell is the Benevolent Dictator for Life (BDFL).
 - Thomas Caswell
 - Eric Firing
 - Ryan May
-- TBD
+- Tim Hoffmann
 - TBD
 - TBD
 - TBD


### PR DESCRIPTION
Tim Hoffmann (@timhoffm ) has accepted an invitation to join the Steering Council.  Will be "in force" when this PR is merged.