### PR TITLE
Add "Principal Engineer" deputy project lead

### DIFF
--- a/deputy_project_leads.md
+++ b/deputy_project_leads.md
@@ -20,7 +20,7 @@ An individual may be the RM for more than one release series at the
 same time.
 
 
-## API consistency Leader
+## API Consistency Leader
 
 Matplotlib is constantly making small changes to its API: enhancements
 that add new features, bug fixes that unavoidably change behavior, and

--- a/deputy_project_leads.md
+++ b/deputy_project_leads.md
@@ -38,6 +38,20 @@ This include checking that:
   the existing functions
 
 
+## Principal Engineer
+
+Matplotlib relies on a wide and deep code base to implement its public
+API; the low-level details need to be correct to faithfully implement
+that API.  In contrast to the API Consistency Leader, who is
+responsible for what the library does, the Principal Engineer is
+responsible for how. They are the point of contact for:
+
+- rendering
+- file formats
+- text/font handling
+- integration with GUI toolkits
+- internal data structures and API
+
 ## Reference Documentation Leader
 
 The Matplotlib API reference documentation is split between the docstrings and

--- a/people.md
+++ b/people.md
@@ -10,6 +10,7 @@ These are the current deputy project leader positions:
 
 - **Release Mangagers** :  (3.3, 3.4) : Elliott Sales de Andrade
 - **API Consistency Leader** : Tim Hoffmann
+- **Principal Engineer**: Antony Lee
 - **Reference Documentation Leader** :
 - **Narrative Documentation Leader** :
 - **Secretary** : Jody Klymak

--- a/people.md
+++ b/people.md
@@ -9,7 +9,7 @@ Thomas Caswell is the current Project Lead
 These are the current deputy project leader positions:
 
 - **Release Mangagers** :  (3.3, 3.4) : Elliott Sales de Andrade
-- **API consistency Leader** : Tim Hoffmann
+- **API Consistency Leader** : Tim Hoffmann
 - **Reference Documentation Leader** :
 - **Narrative Documentation Leader** :
 - **Secretary** : Jody Klymak


### PR DESCRIPTION
Nominate Antony Lee to the position.

There is also an incidental change to the spelling of "API Consistency Lead"