### PR TITLE
DOC: add CoC committee

### DIFF
--- a/people.md
+++ b/people.md
@@ -30,6 +30,13 @@ NOTE: The Council will be initially formed through PL nomination from the set
 of existing Developers who meet the criteria laid out in the governance
 document.
 
+### CoC Subcommittee
+
+- Thomas Caswell [@tacaswell](https://github.com/tacaswell)
+- Eric Firing [@efiring](https://github.com/efiring)
+- Ryan May [@dopplershift](https://github.com/dopplershift)
+- Tim Hoffmann [@timhoffm](https://github.com/timhoffm)
+- Hannah Aizenman [@story645](https://github.com/story645)
 
 ### NumFOCUS Subcommittee
 


### PR DESCRIPTION
As discussed on the 2022-06-30 call.

We plan to re-vamp this sub-committee in the next 9-12 months, but start with this list.