### PR TITLE
Revert "MNT: pin to old pydata-sphinx-theme"

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,5 +1,4 @@
 # List required packages in this file, one per line.
-pydata-sphinx-theme<0.9.0
 mpl-sphinx-theme
 myst-parser
 sphinx<5  # pinned because current pydata-sphinx-theme is incompatible


### PR DESCRIPTION
Reverts matplotlib/governance#27
#27 duplicates a change that already went in when I merged #25.