### PR TITLE
comm lead should review changes to guidlines

### DIFF
--- a/communications_guidelines.md
+++ b/communications_guidelines.md
@@ -72,4 +72,4 @@ These guidelines are applicable when acting as a representative of Matplotlib (f
 * Acknowleges that it is a sometimes frustrating tangle of bits & bobbles that can confuse even the folks who work on it & signal boosts their confuzzlment. 
 
 ## Changes to Guidelines
-Changes to the communications guidelines must be reviewed by the communications lead (currently the community manager) and changes to specific platform guidlines (e.g. twitter, instagram) must be reviewed by the person responsible for that platform when different from the communications lead. If there is no consensus, decisions about communications guidelines revert to the communications lead. 
+Changes to the communications guidelines must be reviewed by the community manager and changes to specific platform guidlines (e.g. twitter, instagram) must be reviewed by the person responsible for that platform when different from the community manager. If there is no consensus, decisions about communications guidelines revert to the community manager. 


### PR DESCRIPTION
Added a section to the communications guidelines requiring that changes to the guidelines must be reviewed by the communications lead. Also the social media platform lead as appropriate even though my working assumption is any community/communications lead would loop in platform people on things that would affect them.  Technically there are sections of this guide that don't need sign off, but it seemed easier to just make it a blanket thing. 

I think the requirement should be **review** not *approval* because I don't think the communications lead should necessarily dictate the guidelines, but I do think that they should always be looped in since they are responsible for implementing changes. 

I was inspired by the [api section](https://matplotlib.org/devdocs/devel/contributing.html#contributing-code) of the docs which states: 
![image](https://user-images.githubusercontent.com/1300499/189510029-6ef45c8b-5dfc-4e61-88bf-6731bef1330f.png)

attn: @dopplershift 