### PR TITLE
Update to 3.6 Sphinx theme

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -72,16 +72,20 @@ html_logo = "_static/logo2.svg"
 
 
 html_sidebars = {
-    "index": ["search-field.html"],
-    "**": ["search-field.html", "globaltoc.html"],
+    "index": [],
+    "**": ["globaltoc.html"],
 }
 
 is_release_build = tags.has("release")  # noqa
 
 
 html_theme_options = {
-    "native_site": True,
-    "logo_link": "index",
+    "navbar_links": "server-stable",
+    "logo": {
+        "link": "index",
+        "image_light": "images/logo2.svg",
+        "image_dark": "images/logo_dark.svg",
+    },
     "collapse_navigation": not is_release_build,
     "show_prev_next": False,
     # Toc options

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,5 +1,3 @@
 # List required packages in this file, one per line.
-mpl-sphinx-theme
+mpl-sphinx-theme~=3.6.0
 myst-parser
-sphinx<5  # pinned because current pydata-sphinx-theme is incompatible
-pydata-sphinx-theme<0.9  # temporary workaround to make the docs build


### PR DESCRIPTION
Also, remove search from sidebar to match.

This also fixes the navigation links in the header which are currently linking to e.g. `https://matplotlib.org/governance/plot_types/` instead of `stable`.