### PR TITLE
ci: Fix release publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
             github.event_name == 'push' && github.ref == 'refs/heads/main'
           }}" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Upgrade jinja
         run: pip install -U jinja2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,15 +1,19 @@
+---
 name: Docs
 
 on: [push, pull_request]
-
-env:
-  IS_RELEASE: |
-    ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+      - name: Check if release
+        id: setup
+        run: |
+          echo "IS_RELEASE=${{
+            github.event_name == 'push' && github.ref == 'refs/heads/main'
+          }}" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v2
 
       - name: Upgrade jinja
@@ -20,13 +24,13 @@ jobs:
 
       - name: Build
         run: |
-          if [ "x$IS_RELEASE" == "xtrue" ]; then
+          if [ "${{ steps.setup.outputs.IS_RELEASE }}" == "true" ]; then
             O="-t release"
           fi
           make html O="$O"
 
       - name: Publish
-        if: ${{ env.IS_RELEASE == 'true' }}
+        if: ${{ steps.setup.outputs.IS_RELEASE == 'true' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/conf.py
+++ b/conf.py
@@ -88,4 +88,8 @@ html_theme_options = {
 
 include_analytics = is_release_build
 if include_analytics:
-    html_theme_options["google_analytics_id"] = "UA-55954603-1"
+    html_theme_options["analytics"] = {
+        "plausible_analytics_domain": "matplotlib.org",
+        "plausible_analytics_url":
+            "https://views.scientific-python.org/js/script.js"
+    }


### PR DESCRIPTION
We can see in [the latest build on `main`](https://github.com/matplotlib/governance/actions/runs/6091172247/job/16527338234) that the Publish step did not run, which broke due to my change in #34. The top-level `env` is not available as an `env` context directly, and apparently jobs outputs is the best way to do this.

Once that is fixed, it turns out [that the Analytics is broken](https://github.com/QuLogic/mpl-governance/actions/runs/6093516044/job/16533318751), so I updated it to use Plausible, which is [now working and publishing on `main`](https://github.com/QuLogic/mpl-governance/actions/runs/6093565406/job/16533445552), and [publishing is skipped on other branches](https://github.com/QuLogic/mpl-governance/actions/runs/6093574008/job/16533466593).

The workflow is also complaining that "The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/" so I've updated checkout to v4.