### PR TITLE
GOV: switch Code of Conduct to use NumFOCUS CoC + WG

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -265,14 +265,6 @@ interactions with NumFOCUS which will include external members.
   Subcommittee through employment or contracting work. This avoids effective
   majorities resting on one person.
 
-### Code of Conduct Subcommittee
-
-This committee should be between 3 and 7 people, at least one of whom is on the
-Steering Council and at least one who is not.  This committee in responsible for
-fielding and addressing CoC reports that happen within our digital and physical
-spaces.  They will maintain their own private mailing list and reporting
-address.  Detailed policy on how to handle CoC will be documented elsewhere.
-
 
 ## Deputy Project Leaders
 
@@ -304,12 +296,20 @@ individual may hold more than one DPL simultaneously.
 Matplotlib has a number of domain specific packages under it's umbrella and
 hosted on the Matplotlib github organizations.  These projects will each have
 their own Project Leader who can run the projects as they see fit consistent with
-the Matplotlib Code of Conduct.
+the [NumFOCUS Code of Conduct](https://numfocus.org/code-of-conduct).
 
 If a project would like to be hosted on the Matplotlib organization on
 GitHub, they can petition the SC and be accepted by a simple majority
 vote.  A project can leave the organization at anytime and can be
 removed from the organization by an 2/3 majority vote of the SC.
+
+## Code of Conduct
+
+Matplotlib uses the NumFOCUS Code of Conduct with reports handled by the
+NumFOCUS Code of Conduct Working Group.  Matplotlib uses the "response"
+agreement where the response is handled by they NumFOCUS Code of Conduct
+Working Group with technical support (e.g. to conduct administrative tasks
+like blocking users) from the project when required.
 
 ## Institutional Partners and Funding
 

--- a/governance.md
+++ b/governance.md
@@ -307,7 +307,7 @@ removed from the organization by an 2/3 majority vote of the SC.
 
 Matplotlib uses the NumFOCUS Code of Conduct with reports handled by the
 NumFOCUS Code of Conduct Working Group.  Matplotlib uses the "response"
-agreement where the response is handled by they NumFOCUS Code of Conduct
+agreement where the response is handled by the NumFOCUS Code of Conduct
 Working Group with technical support (e.g. to conduct administrative tasks
 like blocking users) from the project when required.
 

--- a/people.md
+++ b/people.md
@@ -30,14 +30,6 @@ NOTE: The Council will be initially formed through PL nomination from the set
 of existing Developers who meet the criteria laid out in the governance
 document.
 
-### CoC Subcommittee
-
-- Thomas Caswell [@tacaswell](https://github.com/tacaswell)
-- Eric Firing [@efiring](https://github.com/efiring)
-- Ryan May [@dopplershift](https://github.com/dopplershift)
-- Tim Hoffmann [@timhoffm](https://github.com/timhoffm)
-- Hannah Aizenman [@story645](https://github.com/story645)
-
 ### NumFOCUS Subcommittee
 
 - Thomas Caswell [@tacaswell](https://github.com/tacaswell)


### PR DESCRIPTION
This:
 - switches the Code of Conduct from Contributor Covenant to the NumFOCUS Code of Conduct
 - switches reporting from our Code of Conduct sub-committee to the NumFOCUS Code of Conduct Working Group


After this is done we will need to have our existing mailing list either forward to the working group or auto-respond with directions with alternate reporting instructions.