### PR TITLE
Add template for new triage team invitation

### DIFF
--- a/templates.md
+++ b/templates.md
@@ -16,7 +16,7 @@ Subject: Matplotlib commit rights
 <name>,
 
 
-We would like to invite you to join the Matplotlib organization on github with
+We would like to invite you to join the Matplotlib organization on GitHub with
 commit rights to the main Matplotlib repository! (you should have the GH emails
 in your inbox). If you are also on the Matplotlib Discourse forum, we will add
 you to the "maintainers" group there as well.
@@ -25,7 +25,7 @@ Please see https://matplotlib.org/devel/coding_guide.html#detailed-guidelines
 and remember to be kind during your reviews.
 
 In addition to the discussions on GitHub and Discourse, we have weekly open
-developer calls that you are invited to join (links below) on Thurdays at
+developer calls that you are invited to join (links below) on Thursdays at
 <MEETING TIME> UTC <(their timezone if you know it)>.
 
 If you accept, welcome (formally) to the team!
@@ -65,7 +65,7 @@ Subject: Matplotlib triage rights
 <name>,
 
 
-We would like to invite you to join the Matplotlib organization on github with
+We would like to invite you to join the Matplotlib organization on GitHub with
 triage rights to the main Matplotlib repository! (you should have the GH emails
 in your inbox). If you are also on the Matplotlib Discourse forum, we will add
 you to the "triage" group there as well.
@@ -79,7 +79,7 @@ Please see https://matplotlib.org/devdocs/devel/triage.html and let us know if
 you have any questions about the process.
 
 In addition to the discussions on GitHub and Discourse, we have weekly open
-developer calls that you are invited to join (links below) on Thurdays at
+developer calls that you are invited to join (links below) on Thursdays at
 <MEETING TIME> UTC <(their timezone if you know it)>. 
 
 If you accept, welcome (formally) to the team!

--- a/templates.md
+++ b/templates.md
@@ -67,7 +67,7 @@ Subject: Matplotlib triage rights
 
 We would like to invite you to join the Matplotlib organization on GitHub with
 triage rights to the main Matplotlib repository! (you should have the GH emails
-in your Github inbox). If you are also on the Matplotlib Discourse forum, we will add
+in your GitHub inbox). If you are also on the Matplotlib Discourse forum, we will add
 you to the "triage" group there as well.
 
 This will allow you to help with triaging issues and pull requests, but not to

--- a/templates.md
+++ b/templates.md
@@ -18,7 +18,7 @@ Subject: Matplotlib commit rights
 
 We would like to invite you to join the Matplotlib organization on GitHub with
 commit rights to the main Matplotlib repository! (you should have the GH emails
-in your inbox). If you are also on the Matplotlib Discourse forum, we will add
+in your GitHub inbox). If you are also on the Matplotlib Discourse forum, we will add
 you to the "maintainers" group there as well.
 
 Please see https://matplotlib.org/devel/coding_guide.html#detailed-guidelines
@@ -53,7 +53,7 @@ join the Matplotlib organization as a committer to core repository!
 
 This is a template for writing emails to invite people to join the organization.
 
-This should be sent out concurrently with the invitation.
+This should be sent out concurrently with the GitHub invitation.
 
 CC the steering council.
 
@@ -67,7 +67,7 @@ Subject: Matplotlib triage rights
 
 We would like to invite you to join the Matplotlib organization on GitHub with
 triage rights to the main Matplotlib repository! (you should have the GH emails
-in your inbox). If you are also on the Matplotlib Discourse forum, we will add
+in your Github inbox). If you are also on the Matplotlib Discourse forum, we will add
 you to the "triage" group there as well.
 
 This will allow you to help with triaging issues and pull requests, but not to
@@ -92,7 +92,7 @@ zoom: https://zoom.us/j/384435716?pwd=WFpxVWxoYXArTDFzN1lWaHNoOE8xZz09
 
 ## Announce new triager
 
-In "Announcements" section of discourse
+In the "Announcements" section of discourse
 
 ```md
 Welcome <name> to the Matplotlib organization

--- a/templates.md
+++ b/templates.md
@@ -6,7 +6,7 @@ This is a template for writing emails to invite people to join the organization.
 
 This should be sent out concurrently with the invitation.
 
-CC the streeing council.
+CC the steering council.
 
 
 
@@ -18,14 +18,15 @@ Subject: Matplotlib commit rights
 
 We would like to invite you to join the Matplotlib organization on github with
 commit rights to the main Matplotlib repository! (you should have the GH emails
-in your inbox).
+in your inbox). If you are also on the Matplotlib Discourse forum, we will add
+you to the "maintainers" group there as well.
 
 Please see https://matplotlib.org/devel/coding_guide.html#detailed-guidelines
 and remember to be kind during your reviews.
 
-In addition to the discussions on GitHub we have weekly open developer calls
-that you are invited to join (links below) on Thurdays at <MEETING TIME> UTC
-<(their timezone if you know it)>.
+In addition to the discussions on GitHub and Discourse, we have weekly open
+developer calls that you are invited to join (links below) on Thurdays at
+<MEETING TIME> UTC <(their timezone if you know it)>.
 
 If you accept, welcome (formally) to the team!
 
@@ -48,6 +49,59 @@ We are happy to announce that <name/@on discourse> (<link to GH profile>) has ac
 join the Matplotlib organization as a committer to core repository!
 ```
 
+## Offer triage rights
+
+This is a template for writing emails to invite people to join the organization.
+
+This should be sent out concurrently with the invitation.
+
+CC the steering council.
+
+
+
+```
+Subject: Matplotlib triage rights
+
+<name>,
+
+
+We would like to invite you to join the Matplotlib organization on github with
+triage rights to the main Matplotlib repository! (you should have the GH emails
+in your inbox). If you are also on the Matplotlib Discourse forum, we will add
+you to the "triage" group there as well.
+
+This will allow you to help with triaging issues and pull requests, but not to
+push code to the repository. We hope that this will allow you to get more
+involved with the project and eventually become a committer if you are
+interested.
+
+Please see https://matplotlib.org/devdocs/devel/triage.html and let us know if
+you have any questions about the process.
+
+In addition to the discussions on GitHub and Discourse, we have weekly open
+developer calls that you are invited to join (links below) on Thurdays at
+<MEETING TIME> UTC <(their timezone if you know it)>. 
+
+If you accept, welcome (formally) to the team!
+
+YOUR NAME (on behalf of the SC)
+
+Agendas: https://hackmd.io/@matplotlib
+zoom: https://zoom.us/j/384435716?pwd=WFpxVWxoYXArTDFzN1lWaHNoOE8xZz09
+```
+
+## Announce new triager
+
+In "Announcements" section of discourse
+
+```md
+Welcome <name> to the Matplotlib organization
+----
+
+
+We are happy to announce that <name/@on discourse> (<link to GH profile>) has accepted an invitation to
+join the Matplotlib organization as a triager to the core repository!
+```
 
 ## New Steering Council Members
 


### PR DESCRIPTION
As discussed in developer meetings and Discourse.

I took the liberty of fixing a few details on the template for new maintainers as well. Happy to address any feedback!